### PR TITLE
Fix "object 'need_chrpos' not found" error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MRlap
 Title: MRlap is an R-package to perform two-sample Mendelian Randomisation (MR) analyses using (potentially) overlapping samples
-Version: 0.0.3.1
+Version: 0.0.3.2
 Author: Ninon Mounier
 Maintainer: Ninon Mounier <mounier.ninon@gmail.com>
 Description: MR estimates can be subject to different types of biases due to the overlap between the exposure and outcome samples, the use of weak instruments and Winner’s curse. Our approach simultaneously accounts and corrects for all these biases, using cross-trait LD-score regression (LDSC) to approximate the overlap. It requires only GWAS summary statistics. Estimating the corrected effect using our approach can be performed as a sensitivity analysis: if the corrected effect do not significantly differ from the observed effect, then IVW-MR estimate can be safely used. However, when there is a significant difference, corrected effects should be preferred as they should be less biased, independently of the sample overlap.   

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -117,6 +117,8 @@ MRlap <- function(exposure,
     hm3 = normalizePath(hm3)
   } else stop("hm3 : wrong format, should be character", call. = FALSE)
 
+  ## default is to need the CHR:POS info. Only exception is if using local Plink clumping
+  need_chrpos=TRUE
 
   ## user-provided SNP list?
   if (!do_pruning){
@@ -145,7 +147,6 @@ MRlap <- function(exposure,
     if(MR_pruning_LD<0) stop("MR_pruning_LD : should be positive", call. = FALSE)
     if(MR_pruning_LD>1) stop("MR_pruning_LD : should not be larger than 1", call. = FALSE)
 
-    need_chrpos=TRUE
     if(MR_pruning_LD>0){
       if(verbose) cat("The LD threshold used for pruning MR instruments is:", MR_pruning_LD, "\n")
       if(!is.null(MR_plink)){


### PR DESCRIPTION
Responding to issue #12

`need_chrpos` was only defined when `do_pruning==TRUE` which was throwing this error.

Not sure whether `need_chrpos` always needs to be TRUE if the user is providing a SNP list? Probably for a separate issue. But this PR should fix the error