### PR TITLE
Return MR-Egger results, and data frame of pruned SNP exposure/outcome associations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MRlap
 Title: MRlap is an R-package to perform two-sample Mendelian Randomisation (MR) analyses using (potentially) overlapping samples
-Version: 0.0.3.2
+Version: 0.0.3.3
 Author: Ninon Mounier
 Maintainer: Ninon Mounier <mounier.ninon@gmail.com>
 Description: MR estimates can be subject to different types of biases due to the overlap between the exposure and outcome samples, the use of weak instruments and Winner’s curse. Our approach simultaneously accounts and corrects for all these biases, using cross-trait LD-score regression (LDSC) to approximate the overlap. It requires only GWAS summary statistics. Estimating the corrected effect using our approach can be performed as a sensitivity analysis: if the corrected effect do not significantly differ from the observed effect, then IVW-MR estimate can be safely used. However, when there is a significant difference, corrected effects should be preferred as they should be less biased, independently of the sample overlap.   

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -232,7 +232,10 @@ MRlap <- function(exposure,
                     "corrected_effect_se" = alpha_corrected_se,
                     "corrected_effect_p" = 2*stats::pnorm(-abs(alpha_corrected/alpha_corrected_se)),
                     "test_difference" = test_diff,
-                    "p_difference" = p_diff))
+                    "p_difference" = p_diff,
+                    "egger_b" = egger_b,
+                    "egger_se" = egger_se,
+                    "egger_intercept_p" = egger_intercept_p))
                     # number of simulations needed to estimate SE/COV s
 
   results_LDSC=with(LDSC_results,

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -257,7 +257,8 @@ MRlap <- function(exposure,
 
   results = list(MRcorrection = results_MR,
                  LDSC = results_LDSC,
-                 GeneticArchitecture = results_GeneticArchitecture)
+                 GeneticArchitecture = results_GeneticArchitecture,
+                 harmonised_mr_data = MR_results$data_pruned)
 
   return(results)
 }

--- a/R/run_MR.R
+++ b/R/run_MR.R
@@ -169,6 +169,7 @@ run_MR <- function(exposure_data,
               "n_exp" = mean(data_pruned$N.exp),
               "n_out" = mean(data_pruned$N.out),
               "IVs" = data_pruned %>% dplyr::select(.data$std_beta.exp, .data$std_SE.exp),
-              "IVs_rs" = data_pruned$rsid))
+              "IVs_rs" = data_pruned$rsid,
+              "data_pruned" = data_pruned))
 
 }

--- a/R/run_MR.R
+++ b/R/run_MR.R
@@ -156,10 +156,16 @@ run_MR <- function(exposure_data,
   TwoSampleMR::mr_ivw(data_pruned$std_beta.exp, data_pruned$std_beta.out,
                       data_pruned$std_SE.exp, data_pruned$std_SE.out) -> res_MR_TwoSampleMR
 
+  TwoSampleMR::mr_egger_regression(data_pruned$std_beta.exp, data_pruned$std_beta.out,
+                                   data_pruned$std_SE.exp, data_pruned$std_SE.out) -> res_MR_TwoSampleMR_Egger
+
   if(verbose) cat("   ",  "IVW-MR observed effect:", format(res_MR_TwoSampleMR$b, digits = 3), "(", format(res_MR_TwoSampleMR$se, digits=3), ")\n")
 
   return(list("alpha_obs" = res_MR_TwoSampleMR$b,
               "alpha_obs_se" = res_MR_TwoSampleMR$se,
+              "egger_b" = res_MR_TwoSampleMR_Egger$b,
+              "egger_se" = res_MR_TwoSampleMR_Egger$se,
+              "egger_intercept_p" = res_MR_TwoSampleMR_Egger$pval_i,
               "n_exp" = mean(data_pruned$N.exp),
               "n_out" = mean(data_pruned$N.out),
               "IVs" = data_pruned %>% dplyr::select(.data$std_beta.exp, .data$std_SE.exp),


### PR DESCRIPTION
These two changes are just to make life a bit easier when we are running these on our servers. Thought I would post them here in case useful to others. 

It saves a small amount of time for follow-on analyses by running the MR-Egger analysis at run time (especially for the intercept p-value), and also returning the data frame of pruned/harmonised SNP exposure/outcome assocations, for ease of passing to further TwoSampleMR (etc) functions.

If you have done something like:

`A <- MRlap(exp, out, ...)`

Then `A$MRcorrection` now includes:

`$egger_b`
`$egger_se`
`$egger_intercept_p`

And the instrument betas are in `A$harmonised_mr_data`