### PR TITLE
Update returned harmonized data object + NEWS to v0.0.3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MRlap
 Title: MRlap is an R-package to perform two-sample Mendelian Randomisation (MR) analyses using (potentially) overlapping samples
-Version: 0.0.3.3
+Version: 0.0.3.4
 Author: Ninon Mounier
 Maintainer: Ninon Mounier <mounier.ninon@gmail.com>
 Description: MR estimates can be subject to different types of biases due to the overlap between the exposure and outcome samples, the use of weak instruments and Winner’s curse. Our approach simultaneously accounts and corrects for all these biases, using cross-trait LD-score regression (LDSC) to approximate the overlap. It requires only GWAS summary statistics. Estimating the corrected effect using our approach can be performed as a sensitivity analysis: if the corrected effect do not significantly differ from the observed effect, then IVW-MR estimate can be safely used. However, when there is a significant difference, corrected effects should be preferred as they should be less biased, independently of the sample overlap.   

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# MRlap 0.0.3.4 (2025-01-11)
+
+## Changes
+
+- Update col names for the returned `harmonised_mr_data` object that contains the pruned and aligned instruments (this was not originally intended to be returned, so did not have consistent naming)
+
+
+# MRlap 0.0.3.3 (2025-01-09)
+
+## Changes
+
+- Add MR-Egger test to the output object 
+- Include the pruned and harmonised instruments in the output object
+- Fix `run_MR()` internal function (there was a `transmute()` function that still referenced CHR and POS even if not required)
+
+
+# MRlap 0.0.3.2 (2023-11-08)
+
+## Changes
+
+- Fix issue #12 - `need_chrpos` not correctly specified throughout following inclusion of local plink/reference options
+
+
 # MRlap 0.0.3.1 (2023-10-11)
 
 ## Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - Update col names for the returned `harmonised_mr_data` object that contains the pruned and aligned instruments (this was not originally intended to be returned, so did not have consistent naming)
 - Recognise GWAS catalog format headers automatically
+- Include `results_table` in output list. The standard TwoSampleMR results with additional row for corrected IVW (just makes it easier to quickly parse)
 
 
 # MRlap 0.0.3.3 (2025-01-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 - Update col names for the returned `harmonised_mr_data` object that contains the pruned and aligned instruments (this was not originally intended to be returned, so did not have consistent naming)
+- Recognise GWAS catalog format headers automatically
 
 
 # MRlap 0.0.3.3 (2025-01-09)

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -217,6 +217,29 @@ MRlap <- function(exposure,
   seconds <- Time - minutes * 60
   if(verbose) cat("Runtime of the analysis: ", minutes, " minute(s) and ", seconds, " second(s).  \n")
 
+  # update pruned data variable names to be consistent with format required for TwoSampleMR::mr()
+  data_pruned <- MR_results$data_pruned |>
+    dplyr::rename(SNP=rsid, 
+                  effect_allele.exposure=alt.exp,
+                  other_allele.exposure=ref.exp,
+                  beta.exposure=std_beta.exp,
+                  se.exposure=std_SE.exp,
+                  beta.outcome=std_beta.out,
+                  se.outcome=std_SE.out) |>
+    dplyr::select(-alt.out, -ref.out) |>
+    dplyr::mutate(exposure=exposure_name,
+                  id.exposure=exposure_name,
+                  outcome=outcome_name,
+                  id.outcome=outcome_name,
+                  eaf.exposure=NA,
+                  eaf.outcome=NA,
+                  effect_allele.outcome=effect_allele.exposure,
+                  other_allele.outcome=other_allele.exposure,
+                  mr_keep=TRUE) |>
+    dplyr::relocate(exposure, id.exposure, outcome, id.outcome, .before=SNP) |>
+    dplyr::relocate(eaf.exposure, .after=other_allele.exposure) |>
+    dplyr::relocate(eaf.outcome, .after=other_allele.outcome) |>
+    dplyr::relocate(effect_allele.outcome, other_allele.outcome, .before=Z.out)
 
   # results -> list of 3
   # [[1]] "MR correction"
@@ -258,7 +281,7 @@ MRlap <- function(exposure,
   results = list(MRcorrection = results_MR,
                  LDSC = results_LDSC,
                  GeneticArchitecture = results_GeneticArchitecture,
-                 harmonised_mr_data = MR_results$data_pruned)
+                 harmonised_mr_data = data_pruned)
 
   return(results)
 }

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -291,11 +291,11 @@ MRlap <- function(exposure,
     dplyr::filter(TwoSampleMR_res, method == "MR Egger"),
   )
   
-  TwoSampleMR_res <- TwoSampleMR_res |> mutate(
-    method = if_else(row_number() == 2, "Inverse variance weighted (corrected)", method),
-    b = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect),
-    se = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect_se),
-    p = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect_p)
+  TwoSampleMR_res <- TwoSampleMR_res |> dplyr::mutate(
+    method = dplyr::if_else(dplyr::row_number() == 2, "Inverse variance weighted (corrected)", method),
+    b = dplyr::if_else(dplyr::row_number() == 2, results_MR$corrected_effect, b), 
+    se = dplyr::if_else(dplyr::row_number() == 2, results_MR$corrected_effect_se, se), 
+    pval = dplyr::if_else(dplyr::row_number() == 2, results_MR$corrected_effect_p, pval)
   )
 
   # combine and return

--- a/R/MRlap.R
+++ b/R/MRlap.R
@@ -241,10 +241,12 @@ MRlap <- function(exposure,
     dplyr::relocate(eaf.outcome, .after=other_allele.outcome) |>
     dplyr::relocate(effect_allele.outcome, other_allele.outcome, .before=Z.out)
 
-  # results -> list of 3
+  # results -> list of 5
   # [[1]] "MR correction"
   # [[2]] "LDsc" : h2X / seh2X / h2Y / seh2Y /
   # [[3]] "GeneticArchitecture" : pi / sigma
+  # [[4]] Harmonised MR input data
+  # [[5]] TwoSampleMR table with correct IVW as additional line
   results_MR=with(c(MR_results, correction_results),
                list("observed_effect" = alpha_obs,
                     "observed_effect_se" = alpha_obs_se,
@@ -278,10 +280,30 @@ MRlap <- function(exposure,
                     list("polygenicity" = pi_x,
                          "perSNP_heritability" = sigma2_x))
 
+
+  # Run TwoSampleMR and add correct IVW as row
+  TwoSampleMR_res <- TwoSampleMR::mr(data_pruned)
+  
+  TwoSampleMR_res <- dplyr::bind_rows(
+    dplyr::filter(TwoSampleMR_res, method == "Inverse variance weighted"),
+    dplyr::filter(TwoSampleMR_res, method == "Inverse variance weighted"),
+    dplyr::filter(TwoSampleMR_res, method != "Inverse variance weighted" & method != "MR Egger"),
+    dplyr::filter(TwoSampleMR_res, method == "MR Egger"),
+  )
+  
+  TwoSampleMR_res <- TwoSampleMR_res |> mutate(
+    method = if_else(row_number() == 2, "Inverse variance weighted (corrected)", method),
+    b = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect),
+    se = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect_se),
+    p = if_else(row_number() == 2, "Inverse variance weighted (corrected)", results_MR$$corrected_effect_p)
+  )
+
+  # combine and return
   results = list(MRcorrection = results_MR,
                  LDSC = results_LDSC,
                  GeneticArchitecture = results_GeneticArchitecture,
-                 harmonised_mr_data = data_pruned)
+                 harmonised_mr_data = data_pruned,
+                 results_table = TwoSampleMR_res)
 
   return(results)
 }

--- a/R/tidy_inputGWAS.R
+++ b/R/tidy_inputGWAS.R
@@ -19,15 +19,15 @@ tidy_inputGWAS <- function(GWAS, need_chrpos = TRUE, verbose=FALSE){
 
   if(verbose) cat("# Preparation of the data... \n")
 
-  GWASnames = list(SNPID = c("rsid", "snpid", "snp", "rnpid", "rs"),
-                   CHR = c("chr"),
-                   POS = c("pos"),
-                   ALT = c("a1", "alt", "alts"),
-                   REF = c("ref", "a0", "a2"),
+  GWASnames = list(SNPID = c("rsid", "snpid", "snp", "rnpid", "rs", "rs_id"),
+                   CHR = c("chr", "chromosome"),
+                   POS = c("pos", "base_pair_location"),
+                   ALT = c("a1", "alt", "alts", "effect_allele"),
+                   REF = c("ref", "a0", "a2", "other_allele"),
                    BETA = c("beta", "b", "beta1", "or"),
-                   SE = c("se", "std"),
+                   SE = c("se", "std", "standard_error"),
                    Z = c("z", "zscore"),
-                   N = c("n", "neff"),
+                   N = c("n", "neff", "n_samples"),
                    Ncases = c("n_cases", "ncases", "n_case", "ncase"),
                    Ncontrols = c("n_controls", "ncontrols", "n_control", "ncontrol"))
 

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Pro (2020) - Processor : 2 GHz Quad-Core Intel Core i5 - Memory : 16 GB
 
 A huge thanks to the people helping with `MRlap` improvements!
 
-[Luke Pilling](https://github.com/lukepilling)
+[Luke Pilling](https://github.com/lcpilling)
 
 ## Citation
 


### PR DESCRIPTION
Changes:
1. MRlap now returns the "harmonised_mr_data" i.e., the IVs used in the IVW. This PR updates the naming to be consistent with format for TwoSampleMR::mr() -- see below example -- we were finding it a bit tedious to keep formatting the data in multiple ways to perform additional downstream sensitivity analysis
2. The "NEWS" was a few versions out of date

Example of how update affects using MRlap in a pipeline:

```r
# run standard MRlap analysis
mrlap_res = MRlap::MRlap(
  exposure = gwas1,
  exposure_name = "gwas1",
  outcome = gwas2,
  outcome_name = "gwas2",
  ld = ld,
  hm3 = hm3)

# get harmonised IVs
dat <- mrlap_res$harmonised_mr_data

# run other TwoSampleMR analyses
res <- TwoSampleMR::mr(dat)

# get scatter plot of IVs with "standard" estimates plotted
p1 <- TwoSampleMR::mr_scatter_plot(res, dat)
p[[1]]

# add MRlap corrected estimate line
p[[1]] + 
  ggplot2::geom_abline(intercept=0, slope=mrlap_res$MRcorrection$corrected_effect, color="red")
```
